### PR TITLE
Update platform.ini

### DIFF
--- a/software/arduino/PIA Communicator/platformio.ini
+++ b/software/arduino/PIA Communicator/platformio.ini
@@ -10,9 +10,12 @@
 
 [platformio]
 src_dir = pia_communicator
+
+[env]
 lib_extra_dirs = lib/MCP23S17
 
 [env:nanoatmega328]
 platform = atmelavr
 board = nanoatmega328
 framework = arduino
+monitor_speed = 115200


### PR DESCRIPTION
- Addresses warning on build: `lib_extra_dirs` configuration option is deprecated in section [platformio]! Please move it to global `env` section.
- Sets default baud-rate on PlatformIO Serial Monitor.